### PR TITLE
Allow 2FA for staging and production

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="surl",
-    version="1.0.3",
+    version="1.0.4",
     author="Snap Store Team",
     author_email="daniel.manrique@canonical.com",
     url="https://github.com/canonical/surl",

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -317,9 +317,9 @@ def get_config_from_cli(parser, auth_dir):
                 password=password,
             )
         except errors.StoreServerError as err:
-            if not "twofactor-required" in err.error_list:
+            if "twofactor-required" not in err.error_list:
                 raise
-            
+
             otp = input(f"Second-factor auth for {store_env}: ")
             credentials = store_client.login(
                 permissions=permissions,

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -404,9 +404,11 @@ def get_authorization_header(root, discharge, store_env=None):
 
 def get_client(web_login, store_env, store_type):
     common_args = dict(
-        base_url=CONSTANTS[store_env]["sca_base_url"]
-        if store_type == "snapcraft"
-        else CONSTANTS[store_env]["pubgw_base_url"],
+        base_url=(
+            CONSTANTS[store_env]["sca_base_url"]
+            if store_type == "snapcraft"
+            else CONSTANTS[store_env]["pubgw_base_url"]
+        ),
         storage_base_url="https://storage.staging.snapcraftcontent.com",
         user_agent=DEFAULT_HEADERS["user-agent"],
         application_name="surl",
@@ -415,9 +417,11 @@ def get_client(web_login, store_env, store_type):
     )
     if web_login:
         return StoreClient(
-            endpoints=endpoints.SNAP_STORE
-            if store_type == "snapcraft"
-            else endpoints.CHARMHUB,
+            endpoints=(
+                endpoints.SNAP_STORE
+                if store_type == "snapcraft"
+                else endpoints.CHARMHUB
+            ),
             **common_args,
         )
     else:

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -305,19 +305,29 @@ def get_config_from_cli(parser, auth_dir):
         store_client = get_client(args.web_login, store_env, store_type)
         if not args.web_login:
             password = getpass.getpass(f"Password for {args.email}: ")
-            if store_env == "production":
-                otp = input(f"Second-factor auth for {store_env}: ")
 
-        credentials = store_client.login(
-            permissions=permissions,
-            channels=args.channels,
-            packages=packages,
-            description="surl-client-login",
-            ttl=15552000,  # 180 days
-            email=args.email,
-            password=password,
-            otp=otp,
-        )
+        try:
+            credentials = store_client.login(
+                permissions=permissions,
+                channels=args.channels,
+                packages=packages,
+                description="surl-client-login",
+                ttl=15552000,  # 180 days
+                email=args.email,
+                password=password,
+            )
+        except Exception:
+            otp = input(f"Second-factor auth for {store_env}: ")
+            credentials = store_client.login(
+                permissions=permissions,
+                channels=args.channels,
+                packages=packages,
+                description="surl-client-login",
+                ttl=15552000,  # 180 days
+                email=args.email,
+                password=password,
+                otp=otp,
+            )
     except CliError:
         raise
     except Exception as e:

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 
 import requests
 
-from craft_store import endpoints, StoreClient, UbuntuOneStoreClient
+from craft_store import endpoints, StoreClient, UbuntuOneStoreClient, errors
 from pymacaroons import Macaroon
 
 name = "surl"
@@ -316,7 +316,10 @@ def get_config_from_cli(parser, auth_dir):
                 email=args.email,
                 password=password,
             )
-        except Exception:
+        except errors.StoreServerError as err:
+            if not "twofactor-required" in err.error_list:
+                raise
+            
             otp = input(f"Second-factor auth for {store_env}: ")
             credentials = store_client.login(
                 permissions=permissions,


### PR DESCRIPTION
After the new changes which use the `craft-store` Python package for logging in to the Snap Store, `surl` would assume that only production accounts were protected by 2FA. This change allows `surl` to use 2FA for both production and staging accounts.